### PR TITLE
Fix parser error list creation

### DIFF
--- a/filehandling/src/Parser.cpp
+++ b/filehandling/src/Parser.cpp
@@ -24,7 +24,8 @@ namespace SysMLv2::Files {
         std::cout << parser.start()->toStringTree() << std::endl;
         std::vector<std::shared_ptr<KerML::Entities::Element>> elements;
         auto syntaxErrors  = listener->getSyntaxErrors();
-        std::vector<std::shared_ptr<ParserError>> errorVector = std::vector<std::shared_ptr<SysMLv2::Files::ParserError>>(syntaxErrors.size());
+        std::vector<std::shared_ptr<ParserError>> errorVector;
+        errorVector.reserve(syntaxErrors.size());
         for(const auto& error:syntaxErrors) {
             errorVector.push_back(std::make_shared<ParserError>(boost::uuids::random_generator()(),"",ErrorType::ERROR, error->message()));
         }


### PR DESCRIPTION
## Summary
- fix Parser error vector creation to avoid null entries

## Testing
- `cmake ..` *(fails: Could not find package configuration file provided by "nlohmann_json")*

------
https://chatgpt.com/codex/tasks/task_e_68679a9989048326be5758865c3897d4